### PR TITLE
Deal with Sign in issue and Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # EasyLinks
-EasyLinks is a project that helps people specifially college students to organize their frequently visited websites. People could store their favorite website address as a short, easy-to-remember shortcut. Also, EasyLinks provides the way for college students to quick navigate through their campus and search for other students or faulty member in the same school.
+EasyLinks is a project that helps people specifially college students to organize their frequently visited websites. Users can store their frequently used website urls as a short, easy-to-remember shortcut. Also, EasyLinks offers handy services for college students to navigate on campus and search for students or faulty member's contact info in the same institution.
 
 ## :one: Using EasyLinks
 **To use a link, you can simply type in the link in the search bar or append it at the end of the EasyLinks URL.**
@@ -13,24 +13,24 @@ For example, say we want to use the shortcut `rmp` that is mapped to [rate-my-pr
 ![Image of typing in search bar](searchbar.png)
 
 ## :two: Create and Manage Your Own Links
-**All links created will be shown and can be managed in the [management page](https://easylinks-step-2020.uc.r.appspot.com/manage.html).**
+**All links created will be shown and can be managed on the [management page](https://easylinks-step-2020.uc.r.appspot.com/manage.html).**
 
 You can create and use two types of links:
 | Type | Description |
 | - | - |
-| Public links | Created by one person but can be viewed and used by all people using EasyLinks.|
-| Private links| Created by one person and can be only be viewed and used by that person.       |
+| Public links | Created by one user but can be viewed and used by all users.|
+| Private links| Created by one user and can be only be viewed and used by that user.       |
 
 **Note:**
-  1. To use private links, you may need to login with your email first.
-  2. `~next`, `~who`, `~next` are reserved shortcuts for other functionalities. You may not create or change links starting from those. For more information, [see below](https://github.com/jiaxi312/hello-word/blob/master/README.md#three-calender-next).
+  1. To use private links, you need to login with your email first.
+  2. `~next`, `~who`, `~where` are reserved shortcuts for our provided services. You may not create or change links starting from those. For more information, [see below](https://github.com/jiaxi312/hello-word/blob/master/README.md#three-calender-next).
 
 ## :three: Calender: `~next`
-`~next` will show the next event from your Google calender. 
+`~next` will show the upcoming events of the day on your Google calender. 
 
-EasyLinks will help you to navigate to the meeting place and give you an latest time to leave for that place.
+EasyLinks will help you to navigate to the event location and calculate a set off time.
 
-Also, as most people are WFH, EasyLinks would display the Hangout link for that meeting if there is any.
+Also, as most people are WFH, EasyLinks will also display the Hangout link if there is any.
 
 ### Usage: ###
 
@@ -41,12 +41,12 @@ Type `~next` directly in the search bar.
 Append `~next` to the EasyLinks URL, like `https://easylinks-step-2020.uc.r.appspot.com/~next`.
 
 ### Note: ###
-You may need to log in and authorize EasyLink to view your Google Calender.
+You need to authorize EasyLink to view your Google Calender.
 
 ## :four: People Search: `~who` ###
-`~who` will assist you search people in your school and email them.
+`~who` will assist you to search people in your school and send them emails.
 
-All matching people with their email address will be displayed, and you would have the option to email them.
+All matching people and their associated email addresses will be displayed for user to choose from.
 
 To use it, simply add the name you want to search to the shortcut. See example below.
 
@@ -65,7 +65,7 @@ For now, People Search is only avaliable for students at [Columbia University](h
 ## :five: Navigation: `~where` ##
 `~where` shortcut will search a place you type in.
 
-If you are a college student, you can use place abbrevation in your school for searching!
+If you are a college student, you can use abbreviation of your school buildings for searching!
 
 To use it, simply add the destination name or abbrevation you want to search to the shortcut. See example below.
 
@@ -79,4 +79,4 @@ Type `~where/wat` in the search bar.
 Append `~where/wat` to the EasyLinks URL, like `https://easylinks-step-2020.uc.r.appspot.com/~where/wat`.
 
 ### Note: ###
-For now, abbrevation search will only support building in [Columbia University](https://www.columbia.edu/). More will be added. 
+For now, abbrevation search will only support building in [Columbia University](https://www.columbia.edu/). More will be added in future.

--- a/easylinks/src/main/webapp/script.js
+++ b/easylinks/src/main/webapp/script.js
@@ -23,14 +23,6 @@ function userAuth() {
     } else {
       if (window.location.href.endsWith("manage.html")) {
         window.location.href = stats.trim();
-      } else {
-        // On the home page, display a sign in button
-        var authButton = document.getElementById("authButton");
-        authButton.innerText = "Sign in";
-        authButton.onclick = (function() {
-          window.location.href = stats.trim();
-        });
-        authButton.classList.remove("hidden");
       }
     }
   });


### PR DESCRIPTION
The google's userservice library will return the wrong log in status when the user clears browser cookies and then go to the EasyLinks home page. While the user is still logged in, the status returned is not logged in. More investigation needs to be done, but at this time, we will simply hide the sign in button from the users and directly redirect to the log in page if user is not logged in.