### PR TITLE
Remove "~" prefix from public links

### DIFF
--- a/easylinks/src/main/java/com/google/step/servlets/ManageServlet.java
+++ b/easylinks/src/main/java/com/google/step/servlets/ManageServlet.java
@@ -124,7 +124,7 @@ public class ManageServlet extends HttpServlet {
     Key linkEntityKey = KeyFactory.createKey("Link", id);
     try {
       Entity easyLinkEntity = ServletHelper.DEFAULT_DATASTORE_SERVICE.get(linkEntityKey);
-      String shortcut = "~" + (String) easyLinkEntity.getProperty("shortcut");
+      String shortcut = (String) easyLinkEntity.getProperty("shortcut");
       
       // Check if the shortcut already created in the DataStore
       if (ServletHelper.fetchUrlWithDefault(shortcut, ServletHelper.ADMIN, null) != null) {
@@ -132,7 +132,7 @@ public class ManageServlet extends HttpServlet {
         response.getWriter().println("Repeated shortcut.");
         return;
       }
-      easyLinkEntity.setProperty("shortcut", shortcut);
+
       easyLinkEntity.setProperty("email", ServletHelper.ADMIN);
       easyLinkEntity.setProperty("creator", ServletHelper.USERSERVICE.getCurrentUser().getEmail());
       ServletHelper.DEFAULT_DATASTORE_SERVICE.put(easyLinkEntity);
@@ -148,7 +148,6 @@ public class ManageServlet extends HttpServlet {
     try {
       Entity easyLinkEntity = ServletHelper.DEFAULT_DATASTORE_SERVICE.get(linkEntityKey);
       String shortcut = (String) easyLinkEntity.getProperty("shortcut");
-      shortcut = shortcut.substring(1);
       String creator = (String) easyLinkEntity.getProperty("creator");
 
       // Check if the user is the creator of the public link
@@ -164,7 +163,7 @@ public class ManageServlet extends HttpServlet {
         response.getWriter().println("Repeated shortcut.");
         return;
       }
-      easyLinkEntity.setProperty("shortcut", shortcut);
+      
       easyLinkEntity.setProperty("email", (String) easyLinkEntity.getProperty("creator"));
       ServletHelper.DEFAULT_DATASTORE_SERVICE.put(easyLinkEntity);
     } catch(Exception e) {

--- a/easylinks/src/main/webapp/display_script.js
+++ b/easylinks/src/main/webapp/display_script.js
@@ -68,9 +68,7 @@ function showPublicLinksInCurrentPage() {
 }
 
 function goPrivate(btn) {
-  var message = "Are you sure you want to make this link private?\n";
-  message += "To use the link in the future, eliminate '~' at the beginning.\n";
-  message += "e.g. use 'hello' instead of '~hello'.";
+  var message = "Are you sure you want to make this link private?";
   if (window.confirm(message)) {
     const params = new URLSearchParams();
     params.append('id', $(btn).closest("tr").find("td:first").text());

--- a/easylinks/src/main/webapp/script.js
+++ b/easylinks/src/main/webapp/script.js
@@ -3,7 +3,7 @@
 var links = [];
 var offset = 0;
 var TOTAL_PAGES = 0;
-const ROWS_PER_PAGE = 20;
+const ROWS_PER_PAGE = 10;
 
 /**
  * Checks user authentication. 
@@ -135,9 +135,7 @@ function deleteLink(btn) {
 }
 
 function goPublic(btn) {
-  var message = "Public links cannot be make back to private again.\n";
-  message += "To use the link in the future, append '~' at the beginning.\n";
-  message += "e.g. use '~hello' instead of 'hello'.";
+  var message = "Are you sure you want to make this link public?";
   if (window.confirm(message)) {
     const params = new URLSearchParams();
     params.append('id', $(btn).closest("tr").find("td:first").text());


### PR DESCRIPTION
As we discussed during the group meeting, public link do not need "~" prefix anymore.