### PR TITLE
Include all links the user has access to on management page

### DIFF
--- a/easylinks/src/main/java/com/google/step/servlets/LoginServlet.java
+++ b/easylinks/src/main/java/com/google/step/servlets/LoginServlet.java
@@ -23,4 +23,11 @@ public class LoginServlet extends HttpServlet {
                                                 .createLoginURL("/index.html"));
     }
   }
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    response.setContentType("text/html");
+    response.getWriter().println(ServletHelper.USERSERVICE
+                                              .getCurrentUser().getEmail());
+  }
 }

--- a/easylinks/src/main/java/com/google/step/servlets/ManageServlet.java
+++ b/easylinks/src/main/java/com/google/step/servlets/ManageServlet.java
@@ -9,6 +9,8 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.datastore.Query.Filter;
 import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.CompositeFilter;
+import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.Entity;
@@ -27,11 +29,16 @@ public class ManageServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     final String email = ServletHelper.USERSERVICE.isUserLoggedIn() ?
         ServletHelper.USERSERVICE.getCurrentUser().getEmail() : null;
-    // Define a query rule that retreives records based on email and 
-    // sorts links in alphabetically by shortcut
+    // Define a query rule that retreives public links and private links created by the user 
+    // and sorts links alphabetically by shortcut
     if (email == null) return;
-    Filter emailFilter =
-        new FilterPredicate("creator", FilterOperator.EQUAL, email);
+    Filter privateFilter =
+        new FilterPredicate("email", FilterOperator.EQUAL, email);
+    Filter publicFilter =
+        new FilterPredicate("email", FilterOperator.EQUAL, ServletHelper.ADMIN);
+    CompositeFilter emailFilter =
+        CompositeFilterOperator.or(privateFilter, publicFilter);
+
     Query query = new Query("Link")
                       .setFilter(emailFilter)
                       .addSort("shortcut", SortDirection.ASCENDING);
@@ -179,6 +186,21 @@ public class ManageServlet extends HttpServlet {
     }
     response.sendRedirect("/manage.html");
   }
+
+  // private static void getPublicLinksbyOthers(String email) {
+  //   // Filter the links that are public and created by others
+  //   Filter publicFilter =
+  //     new FilterPredicate("email", FilterOperator.EQUAL, ServletHelper.ADMIN);
+  //   Filter otherFilter =
+  //     new FilterPredicate("creator", FilterOperator.NOT_EQUAL, email);
+  //   CompositeFilter publicByOthersFilter =
+  //     CompositeFilterOperator.and(publicFilter, otherFilter);
+
+  //   Query query = new Query("Link")
+  //                     .setFilter(emailFilter)
+  //                     .addSort("shortcut", SortDirection.ASCENDING);
+  //   PreparedQuery results = ServletHelper.DEFAULT_DATASTORE_SERVICE.prepare(query);
+  // }
 
     private static final String PROVIDED_LINK = "~";
     private static final String MANAGE_PAGE = "manage.html";

--- a/easylinks/src/main/java/com/google/step/servlets/ManageServlet.java
+++ b/easylinks/src/main/java/com/google/step/servlets/ManageServlet.java
@@ -187,21 +187,6 @@ public class ManageServlet extends HttpServlet {
     response.sendRedirect("/manage.html");
   }
 
-  // private static void getPublicLinksbyOthers(String email) {
-  //   // Filter the links that are public and created by others
-  //   Filter publicFilter =
-  //     new FilterPredicate("email", FilterOperator.EQUAL, ServletHelper.ADMIN);
-  //   Filter otherFilter =
-  //     new FilterPredicate("creator", FilterOperator.NOT_EQUAL, email);
-  //   CompositeFilter publicByOthersFilter =
-  //     CompositeFilterOperator.and(publicFilter, otherFilter);
-
-  //   Query query = new Query("Link")
-  //                     .setFilter(emailFilter)
-  //                     .addSort("shortcut", SortDirection.ASCENDING);
-  //   PreparedQuery results = ServletHelper.DEFAULT_DATASTORE_SERVICE.prepare(query);
-  // }
-
     private static final String PROVIDED_LINK = "~";
     private static final String MANAGE_PAGE = "manage.html";
     private static final String CHANGE_LINK_ERROR = "Process Failed. The reasons may be: \\n"

--- a/easylinks/src/main/webapp/script.js
+++ b/easylinks/src/main/webapp/script.js
@@ -183,19 +183,23 @@ function addLinktoTable(link, tablebody) {
   row.insertCell(1).innerHTML = link.propertyMap.status;
   row.insertCell(2).innerHTML = link.propertyMap.shortcut;
   addWordBreakToCell(row.insertCell(3), createHyperLink(link.propertyMap.url));
-  row.insertCell(4).innerHTML = "<button onclick='editLink(this)'>Edit</button>";
-  row.insertCell(5).innerHTML = "<button onclick='deleteLink(this)'>Delete</button>";
 
+  // Add operation buttons if the user is the creator of the link,
+  // otherwise, display "N/A"
   fetch('/~login', {method: 'POST'})
     .then(response => response.text()).then((email) => {
       if (link.propertyMap.creator === email.trim()) {
+        row.insertCell(4).innerHTML = "<button onclick='editLink(this)'>Edit</button>";
+        row.insertCell(5).innerHTML = "<button onclick='deleteLink(this)'>Delete</button>";
         if (link.propertyMap.status === "Private") {
           row.insertCell(6).innerHTML = "<button onclick='goPublic(this)'>Go public</button>";
         } else {
           row.insertCell(6).innerHTML = "<button onclick='goPrivate(this)'>Go private</button>";
         }
       } else {
-        row.insertCell(6).innerHTML = "Not available";
+        row.insertCell(4).innerHTML = "N/A";
+        row.insertCell(5).innerHTML = "N/A";
+        row.insertCell(6).innerHTML = "N/A";
       }
     });
 }

--- a/easylinks/src/main/webapp/script.js
+++ b/easylinks/src/main/webapp/script.js
@@ -73,22 +73,7 @@ function displayLinks() {
       links.slice(offset, offset + ROWS_PER_PAGE) :
       links.slice(offset);
 
-  slice.forEach((link) => {
-    // Add a row to the table, which looks like
-    // id, shortcut, url, edit button, delete button, go-public button
-    var row = tablebody.insertRow();
-    row.insertCell(0).innerHTML = link.key.id;
-    row.insertCell(1).innerHTML = link.propertyMap.status;
-    row.insertCell(2).innerHTML = link.propertyMap.shortcut;
-    addWordBreakToCell(row.insertCell(3), createHyperLink(link.propertyMap.url));
-    row.insertCell(4).innerHTML = "<button onclick='editLink(this)'>Edit</button>";
-    row.insertCell(5).innerHTML = "<button onclick='deleteLink(this)'>Delete</button>";
-    if (link.propertyMap.status === "Private") {
-      row.insertCell(6).innerHTML = "<button onclick='goPublic(this)'>Go public</button>";
-    } else {
-      row.insertCell(6).innerHTML = "<button onclick='goPrivate(this)'>Go private</button>";
-    }
-  });
+  slice.forEach((link) => { addLinktoTable(link, tablebody); });
   
   // Hide id
   $("tr td:first-child, th:eq(0)").hide();
@@ -182,23 +167,37 @@ function getLinkbyShortcut() {
 
   links.forEach((link) => { 
     if (link.propertyMap.shortcut.startsWith(document.getElementById('shortcut').value)) {
-      var row = tablebody.insertRow();
-      row.insertCell(0).innerHTML = link.key.id;
-      row.insertCell(1).innerHTML = link.propertyMap.status;
-      row.insertCell(2).innerHTML = link.propertyMap.shortcut;
-      addWordBreakToCell(row.insertCell(3), createHyperLink(link.propertyMap.url));
-      row.insertCell(4).innerHTML = "<button onclick='editLink(this)'>Edit</button>";
-      row.insertCell(5).innerHTML = "<button onclick='deleteLink(this)'>Delete</button>";
-      if (link.propertyMap.status === "Private") {
-        row.insertCell(6).innerHTML = "<button onclick='goPublic(this)'>Go public</button>";
-      } else {
-        row.insertCell(6).innerHTML = "<button onclick='goPrivate(this)'>Go private</button>";
-      }
-
+      addLinktoTable(link, tablebody);
+      
       // Hide id
       $("tr td:first-child, th:eq(0)").hide();
     }
   });
+}
+
+// Adds a row to the table, which looks like
+// id(hidden), shortcut, url, edit button, delete button, go-public/private button
+function addLinktoTable(link, tablebody) {
+  var row = tablebody.insertRow();
+  row.insertCell(0).innerHTML = link.key.id;
+  row.insertCell(1).innerHTML = link.propertyMap.status;
+  row.insertCell(2).innerHTML = link.propertyMap.shortcut;
+  addWordBreakToCell(row.insertCell(3), createHyperLink(link.propertyMap.url));
+  row.insertCell(4).innerHTML = "<button onclick='editLink(this)'>Edit</button>";
+  row.insertCell(5).innerHTML = "<button onclick='deleteLink(this)'>Delete</button>";
+
+  fetch('/~login', {method: 'POST'})
+    .then(response => response.text()).then((email) => {
+      if (link.propertyMap.creator === email.trim()) {
+        if (link.propertyMap.status === "Private") {
+          row.insertCell(6).innerHTML = "<button onclick='goPublic(this)'>Go public</button>";
+        } else {
+          row.insertCell(6).innerHTML = "<button onclick='goPrivate(this)'>Go private</button>";
+        }
+      } else {
+        row.insertCell(6).innerHTML = "Not available";
+      }
+    });
 }
 
 function redirectToManagePage() {


### PR DESCRIPTION
As we talked about in today's meeting, the user can now see all links he/she has access to on management page:
- operation buttons (delete, edit, go public/private) will not be shown if the creator is not the user

Note: I cannot test this on local server, so please deploy and test this code on live server after merging.